### PR TITLE
forward Keycloak access token to MCP servers 

### DIFF
--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -378,6 +378,7 @@ function createToolInstance({ res, toolName, serverName, toolDefinition, provide
         },
         oauthStart,
         oauthEnd,
+        authorizationHeader: res.req?.headers?.authorization,
       });
 
       if (isAssistantsEndpoint(provider) && Array.isArray(result)) {

--- a/custom/config/k8s/configmaps/librechat.totalsoft.yaml
+++ b/custom/config/k8s/configmaps/librechat.totalsoft.yaml
@@ -42,6 +42,12 @@ actions:
 
 
 #mcpServers:
+mcpServers:
+  ppm-timesheet:
+    type: streamable-http
+    url: "${URL_PPM}" #http://localhost:8000/sse
+    headers:
+      Authorization: "{{LIBRECHAT_USER_ACCESS_TOKEN}}"
 
 # Definition of custom endpoints
 endpoints:

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -183,6 +183,7 @@ Please follow these instructions when using tools from the respective MCP server
     oauthStart,
     oauthEnd,
     customUserVars,
+    authorizationHeader,
   }: {
     user?: TUser;
     serverName: string;
@@ -193,6 +194,7 @@ Please follow these instructions when using tools from the respective MCP server
     requestBody?: RequestBody;
     tokenMethods?: TokenMethods;
     customUserVars?: Record<string, string>;
+    authorizationHeader?: string;
     flowManager: FlowStateManager<MCPOAuthTokens | null>;
     oauthStart?: (authURL: string) => Promise<void>;
     oauthEnd?: () => Promise<void>;
@@ -231,6 +233,7 @@ Please follow these instructions when using tools from the respective MCP server
         options: rawConfig,
         customUserVars: customUserVars,
         body: requestBody,
+        authorizationHeader,
       });
       if ('headers' in currentOptions) {
         connection.setRequestHeaders(currentOptions.headers || {});

--- a/packages/api/src/utils/env.ts
+++ b/packages/api/src/utils/env.ts
@@ -177,8 +177,9 @@ export function processMCPEnv(params: {
   user?: TUser;
   customUserVars?: Record<string, string>;
   body?: RequestBody;
+  authorizationHeader?: string;
 }): MCPOptions {
-  const { options, user, customUserVars, body } = params;
+  const { options, user, customUserVars, body, authorizationHeader } = params;
 
   if (options === null || options === undefined) {
     return options;
@@ -207,7 +208,14 @@ export function processMCPEnv(params: {
   if ('headers' in newObj && newObj.headers) {
     const processedHeaders: Record<string, string> = {};
     for (const [key, originalValue] of Object.entries(newObj.headers)) {
-      processedHeaders[key] = processSingleValue({ originalValue, customUserVars, user, body });
+      let processedValue = processSingleValue({ originalValue, customUserVars, user, body });
+      if (authorizationHeader && processedValue.includes('{{LIBRECHAT_USER_ACCESS_TOKEN}}')) {
+        processedValue = processedValue.replace(
+          /\{\{LIBRECHAT_USER_ACCESS_TOKEN\}\}/g,
+          authorizationHeader,
+        );
+      }
+      processedHeaders[key] = processedValue;
     }
     newObj.headers = processedHeaders;
   }


### PR DESCRIPTION
forward Keycloak access token to MCP servers via {{LIBRECHAT_USER_ACCESS_TOKEN}} placeholder                                                                               
  - Add authorizationHeader param to processMCPEnv() in env.ts                                                                                                              - Pass authorizationHeader through MCPManager.callTool()                                                                                                                
  - Extract req.headers.authorization in MCP.js and forward to callTool                                                                                                     - Add ppm-timesheet MCP server config with Authorization header in k8s configmap                                                                                        

  The MCP server (ppm-timesheet) can now decode the Keycloak JWT to identify
  the authenticated user without requiring a separate auth mechanism.