### PR TITLE
chore(k8s): update PPM endpoint config

### DIFF
--- a/custom/config/k8s/configmaps/librechat.totalsoft.yaml
+++ b/custom/config/k8s/configmaps/librechat.totalsoft.yaml
@@ -211,17 +211,16 @@ endpoints:
           completion: 0
 
     - name: "PPM"
-      baseURL: "http://10.1.48.13:8001/v1"
-      apiKey: "dff700"
+      baseURL: "http://10.1.48.13/v1"
       models:
-        default: ["qwen3-ppm-ft"]
+        default: ["ppm"]
         fetch: false
-      titleModel: 'gemma3:4b' 
+      titleModel: 'gemma4-e4b-base'
       titleEndpoint: "Local Models"
       tokenConfig:
-        "qwen3-ppm-ft":
+        "ppm":
           prompt: 0
-          completion: 0 
+          completion: 0
 
           
     - name: "Assistant"

--- a/custom/config/k8s/configmaps/librechat.totalsoft_dev.yaml
+++ b/custom/config/k8s/configmaps/librechat.totalsoft_dev.yaml
@@ -225,15 +225,14 @@ endpoints:
           prompt: 0
           completion: 0
     - name: "PPM"
-      baseURL: "http://10.1.48.13:8001/v1"
-      apiKey: "dff700"
+      baseURL: "http://10.1.48.13/v1"
       models:
-        default: ["qwen3-ppm-ft"]
+        default: ["ppm"]
         fetch: false
-      titleModel: 'gemma3:4b' 
+      titleModel: 'gemma4-e4b-base'
       titleEndpoint: "Local Models"
       tokenConfig:
-        "qwen3-ppm-ft":
+        "ppm":
           prompt: 0
           completion: 0
           


### PR DESCRIPTION
## Summary
- Switch PPM `baseURL` to `http://10.1.48.13/v1` and drop the hardcoded `apiKey`
- Set PPM `models.default` to `["ppm"]` (tokenConfig key updated to match)
- Switch PPM `titleModel` to `gemma4-e4b-base`

Applied identically to both `librechat.totalsoft.yaml` (prod) and `librechat.totalsoft_dev.yaml` (dev) configmaps.

## Test plan
- [ ] Trigger `Deploy Environment - Totalsoft Local` workflow for `production`
- [ ] Verify PPM endpoint responds at the new baseURL
- [ ] Verify chat completions use model id `ppm`
- [ ] Verify title generation uses `gemma4-e4b-base`